### PR TITLE
Update toolchain and fix `std` name in lakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *~
 /build
 /lake-packages
+lakefile.olean

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,19 +1,20 @@
-{"version": 5,
+{"version": 6,
  "packagesDir": "lake-packages",
  "packages":
  [{"git":
+   {"url": "https://github.com/leanprover/std4",
+    "subDir?": null,
+    "rev": "846e9e1d6bb534774d1acd2dc430e70987da3c18",
+    "opts": {},
+    "name": "std",
+    "inputRev?": "main",
+    "inherited": false}},
+  {"git":
    {"url": "https://github.com/fgdorais/lean4-unicode-basic",
     "subDir?": null,
     "rev": "b9212139bcf4967012149c47fe3b1da859aee786",
     "opts": {},
     "name": "UnicodeBasic",
     "inputRev?": "main",
-    "inherited": false}},
-  {"git":
-   {"url": "https://github.com/leanprover/std4",
-    "subDir?": null,
-    "rev": "7149f40ab67056499919535b8dcc244a5a4150af",
-    "opts": {},
-    "name": "Std",
-    "inputRev?": "main",
-    "inherited": false}}]}
+    "inherited": false}}],
+ "name": "Parser"}

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -11,7 +11,7 @@ package Parser
 @[default_target]
 lean_lib Parser
 
-require Std from git
+require std from git
   "https://github.com/leanprover/std4" @ "main"
 
 require UnicodeBasic from git

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.0.0
+leanprover/lean4:v4.1.0


### PR DESCRIPTION
Lake warns about `std` being required as `Std` (and `lean4-unicode-basic` as `UnicodeBasic`).