### PR TITLE
refactor: do not use `StateT`

### DIFF
--- a/Parser/Basic.lean
+++ b/Parser/Basic.lean
@@ -9,14 +9,14 @@ import Parser.Parser
 import Parser.Stream
 
 namespace Parser
-variable {ε σ τ α β} [Parser.Stream σ τ] [Parser.Error ε σ τ] {m} [Monad m] [MonadExceptOf ε m]
+variable {ε σ τ α β} [Parser.Stream σ τ] [Parser.Error ε σ τ] {m} [Monad m]
 
 /-- `tokenAux next?` reads a token from the stream using `next?` -/
 @[inline]
 def tokenAux (next? : σ → Option (τ × σ)) : ParserT ε σ τ m τ := do
-  match next? (← StateT.get) with
+  match next? (← getStream) with
   | some (tok, stream) =>
-    StateT.set stream
+    let _ ← setStream stream
     return tok
   | none => throwUnexpected
 

--- a/Parser/Char/Numeric.lean
+++ b/Parser/Char/Numeric.lean
@@ -7,7 +7,7 @@ import Parser.Basic
 import Parser.Char.Basic
 
 namespace Parser.Char.ASCII
-variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m] [MonadExceptOf ε m]
+variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 
 @[inline]
 private def decNum (n : Nat := 0) : ParserT ε σ Char m (Nat × Nat) :=

--- a/Parser/Char/Unicode.lean
+++ b/Parser/Char/Unicode.lean
@@ -6,8 +6,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 import Parser.Char.Basic
 
 namespace Parser.Char.Unicode
-variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m] [MonadExceptOf ε m]
-
+variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 /-- parse alphabetic letter character -/
 def alpha : ParserT ε σ Char m Char :=
   withErrorMessage "expected letter" do

--- a/Parser/Parser.lean
+++ b/Parser/Parser.lean
@@ -7,55 +7,82 @@ import Parser.Prelude
 import Parser.Error
 import Parser.Stream
 
-/-- Parser state -/
-protected structure Parser.State (σ τ : Type _) [Parser.Stream σ τ] where
-  /-- Parser stream -/
-  stream : σ
-  /-- Whether the parser has consumed any input -/
-  dirty : Bool := false
-
 /-- Parser result type -/
-inductive Parser.Result (ε σ τ : Type _)
+protected inductive Parser.Result (ε σ : Type _) : Type _ → Type _
   /-- Result: success -/
-  | ok : σ → τ → Result ε σ τ
+  | ok : σ → α → Parser.Result ε σ α
   /-- Result: error -/
-  | error : ε → Result ε σ τ
+  | error : σ → ε → Parser.Result ε σ α
 deriving Repr
 
-/-- `ParserT ε σ τ` monad transformer to parse tokens of type `τ` from the stream `σ` with error type `ε` -/
-@[nolint unusedArguments]
-def ParserT (ε σ τ) (m : Type _ → Type _) [Parser.Stream σ τ] [Parser.Error ε σ τ] :=
-  StateT σ m
-instance (ε σ τ m) [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] : Monad (ParserT ε σ τ m) := inferInstanceAs (Monad (StateT σ m))
-instance (ε σ τ m) [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] [MonadExceptOf ε m] : MonadExceptOf ε (ParserT ε σ τ m) := inferInstanceAs (MonadExceptOf ε (StateT σ m))
+/-- `ParserT ε σ τ` is a monad transformer to parse tokens of type `τ` from the stream type `σ` with error type `ε` -/
+def ParserT (ε σ τ : Type _) [Parser.Stream σ τ] [Parser.Error ε σ τ] (m : Type _ → Type _)
+  (α : Type _) : Type _ := σ → m (Parser.Result ε σ α)
 
-/-- Run parser transformer -/
+/-- Run the monadic parser `p` on input stream `s` -/
 @[inline]
-protected def ParserT.run.{u} {ε σ : Type u} {τ α m} [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] [MonadExceptOf ε m] (p : ParserT ε σ τ m α) (s : σ) : m (Parser.Result ε σ α) :=
-  try
-    let (val, s) ← StateT.run p s
-    return .ok s val
-  catch e =>
-    return .error e
+def ParserT.run [Parser.Stream σ τ] [Parser.Error ε σ τ] (p : ParserT ε σ τ m α) (s : σ) : m (Parser.Result ε σ α) := p s
+
+instance (σ ε τ m) [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] :
+  Monad (ParserT ε σ τ m) where
+  pure x s := return .ok s x
+  bind x f s := x s >>= fun
+    | .ok s a => f a s
+    | .error s e => return .error s e
+  map f x s := x s >>= fun
+    | .ok s a => return .ok s (f a)
+    | .error s e => return .error s e
+  seq f x s := f s >>= fun
+    | .ok s f => x () s >>= fun
+      | .ok s x => return .ok s (f x)
+      | .error s e => return .error s e
+    | .error s e => return .error s e
+  seqLeft x y s := x s >>= fun
+    | .ok s x => y () s >>= fun
+      | .ok s _ => return .ok s x
+      | .error s e => return .error s e
+    | .error s e => return .error s e
+  seqRight x y s := x s >>= fun
+    | .ok s _ => y () s >>= fun
+      | .ok s y => return .ok s y
+      | .error s e => return .error s e
+    | .error s e => return .error s e
+
+instance (σ ε τ m) [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] :
+  MonadExceptOf ε (ParserT ε σ τ m) where
+  throw e s := return .error s e
+  tryCatch p c s := p s >>= fun
+    | .ok s v => return .ok s v
+    | .error s e => (c e).run s
+
+instance (σ ε τ m) [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] :
+  OrElse (ParserT ε σ τ m α) where
+  orElse p q s := p s >>= fun
+    | .ok s v => return .ok s v
+    | .error _ _ => q () s
+
+/-- `Parser ε σ τ` monad to parse tokens of type `τ` from the stream type `σ` with error type `ε` -/
+abbrev Parser (ε σ τ) [Parser.Stream σ τ] [Parser.Error ε σ τ] := ParserT ε σ τ Id
+
+/-- Run parser `p` on input stream `s` -/
+@[inline]
+protected def Parser.run {ε σ τ α} [Parser.Stream σ τ] [Parser.Error ε σ τ] (p : Parser ε σ τ α)
+  (s : σ) : Parser.Result ε σ α := p s
+
+/-- `TrivialParserT σ τ` monad transformer to parse tokens of type `τ` from the stream `σ` with trivial error handling -/
+abbrev TrivialParserT (σ τ) [Parser.Stream σ τ] (m) := ParserT Parser.Error.Trivial σ τ m
+
+/-- `TrivialParser σ τ` monad to parse tokens of type `τ` from the stream `σ` with trivial error handling -/
+abbrev TrivialParser (σ τ) [Parser.Stream σ τ] := Parser Parser.Error.Trivial σ τ
 
 /-- `BasicParserT σ τ` monad transformer to parse tokens of type `τ` from the stream `σ` with basic error handling -/
-abbrev BasicParserT (σ τ) [Parser.Stream σ τ] (m) := ParserT (Parser.Error.Simple σ τ) σ τ m
+abbrev BasicParserT (σ τ) [Parser.Stream σ τ] (m) := ParserT (Parser.Error.Basic σ τ) σ τ m
+
+/-- `BasicParser σ τ` monad to parse tokens of type `τ` from the stream `σ` with basic error handling -/
+abbrev BasicParser (σ τ) [Parser.Stream σ τ] := Parser (Parser.Error.Basic σ τ) σ τ
 
 /-- `SimpleParserT σ τ` monad transformer to parse tokens of type `τ` from the stream `σ` with simple error handling -/
 abbrev SimpleParserT (σ τ) [Parser.Stream σ τ] (m) := ParserT (Parser.Error.Simple σ τ) σ τ m
-
-/-- `Parser ε σ τ` monad to parse tokens of type `τ` from the stream `σ` with error type `ε` -/
-abbrev Parser (ε σ τ) [Parser.Stream σ τ] [Parser.Error ε σ τ] := ParserT ε σ τ (Except ε)
-
-/-- Run parser -/
-@[inline]
-protected def Parser.run {ε σ τ α} [Parser.Stream σ τ] [Parser.Error ε σ τ] (p : Parser ε σ τ α) (s : σ) : Parser.Result ε σ α :=
-  match ParserT.run p s with
-  | .ok v => v
-  | .error e => .error e
-
-/-- `BasicParser σ τ` monad to parse tokens of type `τ` from the stream `σ` with basic error handling -/
-abbrev BasicParser (σ τ) [Parser.Stream σ τ] := Parser (Parser.Error.Simple σ τ) σ τ
 
 /-- `SimpleParser σ τ` monad to parse tokens of type `τ` from the stream `σ` with simple error handling -/
 abbrev SimpleParser (σ τ) [Parser.Stream σ τ] := Parser (Parser.Error.Simple σ τ) σ τ
@@ -63,15 +90,25 @@ abbrev SimpleParser (σ τ) [Parser.Stream σ τ] := Parser (Parser.Error.Simple
 namespace Parser
 variable {ε σ τ m α β} [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m] [MonadExceptOf ε m]
 
+/-- Get parser stream -/
+@[inline]
+def getStream : ParserT ε σ τ m σ :=
+  fun s => return .ok s s
+
+/-- Set parser stream -/
+@[inline]
+def setStream (s : σ) : ParserT ε σ τ m PUnit :=
+  fun _ => return .ok s PUnit.unit
+
 /-- Get stream position from parser -/
 @[inline]
 def getPosition : ParserT ε σ τ m (Stream.Position σ) :=
-  Stream.getPosition <$> StateT.get
+  Stream.getPosition <$> getStream
 
 /-- Set stream position of parser -/
 @[inline]
 def setPosition (pos : Stream.Position σ) : ParserT ε σ τ m PUnit := do
-  StateT.set <| Stream.setPosition (← StateT.get) pos
+  setStream <| Stream.setPosition (← getStream) pos
 
 /-- Throw error on unexpected input -/
 @[inline]
@@ -86,8 +123,7 @@ def throwErrorWithMessage (e : ε) (msg : String) : ParserT ε σ τ m α := do
 /-- Add message on parser error -/
 @[inline]
 def withErrorMessage (msg : String) (p : ParserT ε σ τ m α) : ParserT ε σ τ m α := do
-  try p
-  catch e => throwErrorWithMessage e msg
+  try p catch e => throwErrorWithMessage e msg
 
 @[inline]
 def throwUnexpectedWithMessage (input : Option τ := none) (msg : String) : ParserT ε σ τ m α := do
@@ -103,27 +139,19 @@ def withBacktracking (p : ParserT ε σ τ m α) : ParserT ε σ τ m α := do
     throw e
 
 /-- `withCapture p` parses `p` and returns the output of `p` with the corresponding stream segment -/
-def withCapture (p : ParserT ε σ τ m α) : ParserT ε σ τ m (α × Stream.Segment σ) := do
+def withCapture {ε σ α : Type _} [Parser.Stream σ τ] [Parser.Error ε σ τ] (p : ParserT ε σ τ m α) : ParserT ε σ τ m (α × Stream.Segment σ) := do
   let startPos ← getPosition
   let x ← p
   let stopPos ← getPosition
   return (x, startPos, stopPos)
-
-/- Override default `OrElse` so that the first consumes no input when it fails -/
-@[inline]
-instance : OrElse (ParserT ε σ τ m α) where
-  orElse p q :=
-    try withBacktracking p
-    catch _ => q ()
 
 /-- `first ps` tries parsers from the list `ps` until one succeeds -/
 def first (ps : List (ParserT ε σ τ m α)) (combine : ε → ε → ε := fun _ => id) : ParserT ε σ τ m α := do
   go ps (Error.unexpected (← getPosition) none)
 where
   go : List (ParserT ε σ τ m α) → ε → ParserT ε σ τ m α
-    | [], e => throw e
-    | p :: ps, e =>
-      try withBacktracking p
-      catch f => go ps (combine e f)
-
-end Parser
+    | [], e, s => return .error s e
+    | p :: ps, e, s =>
+      p s >>= fun
+      | .ok s v => return .ok s v
+      | .error _ f => go ps (combine e f) s

--- a/Parser/RegEx/Basic.lean
+++ b/Parser/RegEx/Basic.lean
@@ -65,7 +65,7 @@ def repManyN (n : Nat) (e : RegEx α) :=
   | n+1 => cat e (repManyN n e)
 
 section
-variable {ε σ α β} [Parser.Stream σ α] [Parser.Error ε σ α] {m} [Monad m] [MonadExceptOf ε m]
+variable {ε σ α β} [Parser.Stream σ α] [Parser.Error ε σ α] {m} [Monad m]
 
 /-- Fold over a regex match from the right -/
 protected partial def foldr (f : α → β → β) : RegEx α → ParserT ε σ α m β → ParserT ε σ α m β

--- a/Parser/RegEx/Compile.lean
+++ b/Parser/RegEx/Compile.lean
@@ -43,7 +43,7 @@ import Parser.RegEx.Basic
 namespace Parser.RegEx
 open Char
 
-private abbrev REParser := Parser Unit Substring Char
+private abbrev REParser := TrivialParser Substring Char
 
 mutual
 
@@ -170,7 +170,7 @@ end
 protected def compile? (s : String) : Option (RegEx Char) :=
   match Parser.run (re0 <* endOfInput) s with
   | .ok _ r => some r
-  | .error _ => none
+  | .error _ _ => none
 
 /-- Compiles a regex from a string, panics on faiure -/
 protected def compile! (s : String) : RegEx Char :=

--- a/examples/BNF.lean
+++ b/examples/BNF.lean
@@ -215,7 +215,7 @@ end BNFParser
 def parse (input : String) : Except String BNF.Syntax :=
   match (BNFParser.syntax <* Parser.endOfInput).run input.toSubstring with
   | .ok _ stx => .ok stx
-  | .error e => .error ("error: " ++ toString e)
+  | .error e _ => .error ("error: " ++ toString e)
 
 section Test
 

--- a/examples/JSON.lean
+++ b/examples/JSON.lean
@@ -108,6 +108,6 @@ end
 def validate (str : String) : Bool :=
   match Parser.run (JSON.value <* endOfInput) str with
   | .ok _ _ => true
-  | .error _ => false
+  | .error _ _ => false
 
 end JSON


### PR DESCRIPTION
`ParserT` is no longer implemented using `StateT`. 

Universe levels for `ParserT` and derivatives are now a bit different. Do file an issue if that turns out to be a problem.

`Parser.Result` now also returns the stream state on error. For current users, you can simply ignore the stream state and get basically the former behavior. Do file an issue if that doesn't work as expected.

Closes #25 