### PR TITLE
fix: typo at `Char.string` parser

### DIFF
--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -26,7 +26,7 @@ def chars (tks : String) : ParserT ε σ Char m String :=
 def string [Parser.Error ε Substring Char] (tks : String) : ParserT ε Substring Char m String :=
   withErrorMessage s!"expected {repr tks}" do
     let ⟨str, start, stop⟩ ← getStream
-    if start + tks.endPos < stop ∧ String.substrEq tks 0 str start tks.endPos.byteIdx then
+    if start + tks.endPos ≤ stop ∧ String.substrEq tks 0 str start tks.endPos.byteIdx then
       setPosition (start + tks.endPos)
       return tks
     else

--- a/test/issue-35.lean
+++ b/test/issue-35.lean
@@ -1,0 +1,10 @@
+import Parser.Char
+
+open Parser
+
+def test : Bool :=
+  match Parser.run (Char.string "abc" : SimpleParser Substring Char String) "abc" with
+  | .ok s r => s == "" && r == "abc"
+  | .error _ _ => false
+
+#guard test


### PR DESCRIPTION
Closes #35 