### PR TITLE
feat: modularize

### DIFF
--- a/Parser.lean
+++ b/Parser.lean
@@ -2,11 +2,12 @@
 Copyright © 2022 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Basic
-import Parser.Char
-import Parser.Error
-import Parser.Parser
-import Parser.Prelude
-import Parser.RegEx
-import Parser.Stream
+public import Parser.Basic
+public import Parser.Char
+public import Parser.Error
+public import Parser.Parser
+public import Parser.Prelude
+public import Parser.RegEx
+public import Parser.Stream

--- a/Parser/Basic.lean
+++ b/Parser/Basic.lean
@@ -2,11 +2,14 @@
 Copyright © 2022-2024 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
 import Parser.Prelude
-import Parser.Error
-import Parser.Parser
-import Parser.Stream
+public import Parser.Error
+public import Parser.Parser
+public import Parser.Stream
+
+public section
 
 namespace Parser
 variable [Parser.Stream σ τ] [Parser.Error ε σ τ] [Monad m]

--- a/Parser/Basic.lean
+++ b/Parser/Basic.lean
@@ -422,3 +422,5 @@ trailing `sep`, returns the array of values returned by `p`. This parser never f
 @[inline]
 def sepEndBy1 (sep : ParserT ε σ τ m β) (p : ParserT ε σ τ m α) : ParserT ε σ τ m (Array α) :=
   sepBy1 sep p <* optional sep
+
+end Parser

--- a/Parser/Char.lean
+++ b/Parser/Char.lean
@@ -2,7 +2,8 @@
 Copyright © 2022-2023 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Char.Basic
-import Parser.Char.Numeric
-import Parser.Char.Unicode
+public import Parser.Char.Basic
+public import Parser.Char.Numeric
+public import Parser.Char.Unicode

--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -2,10 +2,12 @@
 Copyright © 2022 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Basic
-import Parser.RegEx.Basic
+public import Parser.Basic
+public import Parser.RegEx.Basic
 
+public section
 namespace Parser.Char
 variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 

--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -8,6 +8,7 @@ public import Parser.Basic
 public import Parser.RegEx.Basic
 
 public section
+
 namespace Parser.Char
 variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 
@@ -168,5 +169,3 @@ def hexDigit : ParserT ε σ Char m (Fin 16) :=
               none
 
 end ASCII
-
-end Parser.Char

--- a/Parser/Char/Numeric.lean
+++ b/Parser/Char/Numeric.lean
@@ -2,10 +2,12 @@
 Copyright © 2022-2023 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Basic
-import Parser.Char.Basic
+public import Parser.Basic
+public import Parser.Char.Basic
 
+public section
 namespace Parser.Char.ASCII
 variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 

--- a/Parser/Char/Unicode.lean
+++ b/Parser/Char/Unicode.lean
@@ -2,9 +2,11 @@
 Copyright © 2022 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Char.Basic
+public import Parser.Char.Basic
 
+public section
 namespace Parser.Char.Unicode
 variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 

--- a/Parser/Char/Unicode.lean
+++ b/Parser/Char/Unicode.lean
@@ -7,6 +7,7 @@ module
 public import Parser.Char.Basic
 
 public section
+
 namespace Parser.Char.Unicode
 variable {ε σ m} [Parser.Stream σ Char] [Parser.Error ε σ Char] [Monad m]
 

--- a/Parser/Error.lean
+++ b/Parser/Error.lean
@@ -2,9 +2,11 @@
 Copyright © 2022-2025 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
 import Parser.Prelude
-import Parser.Stream
+public import Parser.Stream
+public section
 
 /-! # Parser Error
 
@@ -84,7 +86,7 @@ inductive Simple (σ τ) [Parser.Stream σ τ]
   | addMessage : Simple σ τ → Stream.Position σ → String → Simple σ τ
 
 -- The derive handler for `Repr` fails, this is a workaround.
-private def Simple.reprPrec {σ τ} [Parser.Stream σ τ] [Repr τ] [Repr (Stream.Position σ)] :
+protected def Simple.reprPrec {σ τ} [Parser.Stream σ τ] [Repr τ] [Repr (Stream.Position σ)] :
   Simple σ τ → Nat → Std.Format
   | unexpected pos a, prec =>
     Repr.addAppParen
@@ -102,7 +104,7 @@ private def Simple.reprPrec {σ τ} [Parser.Stream σ τ] [Repr τ] [Repr (Strea
         (Std.Format.nest (if prec >= max_prec then 1 else 2)
           (Std.Format.text "Parser.Error.Simple.addMessage" ++
             Std.Format.line ++
-            reprPrec e max_prec ++
+            Simple.reprPrec e max_prec ++
             Std.Format.line ++
             reprArg pos ++
             Std.Format.line ++
@@ -112,7 +114,7 @@ private def Simple.reprPrec {σ τ} [Parser.Stream σ τ] [Repr τ] [Repr (Strea
 instance (σ τ) [Parser.Stream σ τ] [Repr τ] [Repr (Stream.Position σ)] : Repr (Simple σ τ) where
   reprPrec := Simple.reprPrec
 
-private def Simple.toString {σ τ} [Repr τ] [Parser.Stream σ τ] [Repr (Parser.Stream.Position σ)] :
+protected def Simple.toString {σ τ} [Repr τ] [Parser.Stream σ τ] [Repr (Parser.Stream.Position σ)] :
   Simple σ τ → String
   | unexpected pos (some tok) => s!"unexpected token {repr tok} at {repr pos}"
   | unexpected pos none => s!"unexpected token at {repr pos}"

--- a/Parser/Error.lean
+++ b/Parser/Error.lean
@@ -6,6 +6,7 @@ module
 
 import Parser.Prelude
 public import Parser.Stream
+
 public section
 
 /-! # Parser Error

--- a/Parser/Parser.lean
+++ b/Parser/Parser.lean
@@ -2,10 +2,13 @@
 Copyright © 2022-2024 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
 import Parser.Prelude
-import Parser.Error
-import Parser.Stream
+public import Parser.Error
+public import Parser.Stream
+
+public section
 
 /-- Parser result type. -/
 protected inductive Parser.Result.{u} (ε σ α : Type u) : Type u
@@ -19,6 +22,7 @@ protected inductive Parser.Result.{u} (ε σ α : Type u) : Type u
 `ParserT ε σ τ` is a monad transformer to parse tokens of type `τ` from the stream type `σ` with
 error type `ε`.
 -/
+@[expose]
 def ParserT (ε σ τ : Type _) [Parser.Stream σ τ] [Parser.Error ε σ τ] (m : Type _ → Type _)
   (α : Type _) : Type _ := σ → m (Parser.Result ε σ α)
 

--- a/Parser/Parser.lean
+++ b/Parser/Parser.lean
@@ -363,3 +363,5 @@ where
       p s >>= fun
       | .ok s v => return .ok s v
       | .error s f => go ps (combine e f) (Stream.setPosition s savePos)
+
+end Parser

--- a/Parser/Prelude.lean
+++ b/Parser/Prelude.lean
@@ -3,8 +3,9 @@ Copyright © 2022 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights 
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 
-import Batteries
-import UnicodeBasic
+module
+public import Batteries
+public import UnicodeBasic
 
-instance : Std.Stream String.Slice Char where
+public instance : Std.Stream String.Slice Char where
   next? s := s.front? >>= fun c => return (c, s.drop 1)

--- a/Parser/RegEx.lean
+++ b/Parser/RegEx.lean
@@ -2,6 +2,7 @@
 Copyright © 2022-2023 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.RegEx.Basic
-import Parser.RegEx.Compile
+public import Parser.RegEx.Basic
+public import Parser.RegEx.Compile

--- a/Parser/RegEx/Basic.lean
+++ b/Parser/RegEx/Basic.lean
@@ -3,9 +3,11 @@
 Copyright © 2022-2023 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
-import Parser.Basic
+public import Parser.Basic
 
+public section
 namespace Parser
 
 /-- Type of regular expressions -/

--- a/Parser/RegEx/Basic.lean
+++ b/Parser/RegEx/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Parser.Basic
 
 public section
+
 namespace Parser
 
 /-- Type of regular expressions -/
@@ -111,3 +112,5 @@ where
       return ms.set! lvl (some (start, stop))
 
 end
+
+end Parser.RegEx

--- a/Parser/RegEx/Compile.lean
+++ b/Parser/RegEx/Compile.lean
@@ -2,10 +2,13 @@
 Copyright © 2022-2023 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
+module
 
 import Parser.Char
 import Parser.Char.Numeric
-import Parser.RegEx.Basic
+public import Parser.RegEx.Basic
+
+public section
 
 /-! ## RegEx Syntax
 

--- a/Parser/RegEx/Compile.lean
+++ b/Parser/RegEx/Compile.lean
@@ -42,7 +42,6 @@ public section
   `[`, `\`, `]` must be preceded by an escape character `\` within a class.
 -/
 
-
 namespace Parser.RegEx
 open Char
 
@@ -180,3 +179,5 @@ protected def compile! (s : String) : RegEx Char :=
   match RegEx.compile? s with
   | some r => r
   | none => panic! "invalid regular expression"
+
+end Parser.RegEx

--- a/Parser/Stream.lean
+++ b/Parser/Stream.lean
@@ -2,8 +2,9 @@
 Copyright © 2022-2025 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
-
-import Parser.Prelude
+module
+public import Parser.Prelude
+public section
 
 /-! # Parser Stream
 
@@ -42,6 +43,7 @@ attribute [inherit_doc Parser.Stream] Parser.Stream.getPosition Parser.Stream.se
 namespace Parser.Stream
 
 /-- Stream segment type. -/
+@[expose]
 def Segment (σ) [Parser.Stream σ τ] := Stream.Position σ × Stream.Position σ
 
 /-- Start position of stream segment. -/
@@ -55,7 +57,7 @@ abbrev Segment.stop [Parser.Stream σ τ] (s : Segment σ) := s.2
 This wrapper uses the entire stream state as position information; this is not efficient. Always
 prefer tailored `Parser.Stream` instances to this default.
 -/
-@[nolint unusedArguments]
+@[expose]
 def mkDefault (σ τ) [Std.Stream σ τ] := σ
 
 @[reducible]

--- a/Parser/Stream.lean
+++ b/Parser/Stream.lean
@@ -3,7 +3,9 @@ Copyright © 2022-2025 François G. Dorais, Kyrill Serdyuk, Emma Shroyer. All ri
 Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
+
 public import Parser.Prelude
+
 public section
 
 /-! # Parser Stream

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "05954ce1797e6bd6b414c916499fe6dda4a11702",
+   "rev": "603cc6effaf17675bcfc45143fef38130545291d",
    "name": "UnicodeBasic",
    "manifestFile": "lake-manifest.json",
    "inputRev": "main",


### PR DESCRIPTION
This PR makes every Lean file in this package a module, so that downstream users can also be modules. (They don't _have_ to be—non-modules can depend on modules.)

I made everything public by default [as the reference recommends when migrating existing code](https://lean-lang.org/doc/reference/latest/Source-Files-and-Modules/#The-Lean-Language-Reference--Source-Files-and-Modules--Module-System-Errors-and-Patterns--Recipe-for-Porting-Existing-Files), so there should be few breaking changes, although it's impossible to say who was `unfold`ing something they shouldn't have.

This won't build unless [the corresponding PR to UnicodeBasic](https://github.com/fgdorais/lean4-unicode-basic/pull/127) is merged.