### PR TITLE
Replace Substring.Raw with String.Slice

### DIFF
--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -26,29 +26,38 @@ def chars (tks : String) : ParserT ε σ Char m String :=
     return acc
 
 /-- `string tks` accepts and returns string `tks`, otherwise fails -/
-def string [Parser.Error ε Substring.Raw Char] (tks : String) : ParserT ε Substring.Raw Char m String :=
+def string [Parser.Error ε String.Slice Char] (tks : String) :
+    ParserT ε String.Slice Char m String :=
   withErrorMessage s!"expected {repr tks}" do
-    let ⟨str, start, stop⟩ ← getStream
-    if start.offsetBy tks.rawEndPos ≤ stop ∧ String.Pos.Raw.substrEq tks 0 str start tks.rawEndPos.byteIdx then
-      setPosition (start.offsetBy tks.rawEndPos)
+    match (← getStream).dropPrefix? tks with
+    | some s =>
+      setStream s
       return tks
-    else
+    | none =>
       throwUnexpected
 
-/-- `captureStr p` parses `p` and returns the output of `p` with the corresponding Substring.Raw -/
-def captureStr [Parser.Error ε Substring.Raw Char] (p : ParserT ε Substring.Raw Char m α) :
-  ParserT ε Substring.Raw Char m (α × Substring.Raw) := do
-  let ⟨str,_,_⟩ ← getStream
+/-- `captureStr p` parses `p` and returns the output of `p` with the corresponding `String.Slice` -/
+def captureStr [Parser.Error ε String.Slice Char] (p : ParserT ε String.Slice Char m α) :
+  ParserT ε String.Slice Char m (α × String.Slice) := do
+  let s ← getStream
   let (x, start, stop) ← withCapture p
-  return (x, ⟨str, start, stop⟩)
+  -- This should always hold
+  if h : start.IsValid s.str ∧ stop.IsValid s.str ∧ start ≤ stop then
+    return (x, ⟨s.str, ⟨start, h.1⟩ , ⟨stop, h.2.1⟩, String.Pos.le_iff.1 h.2.2⟩)
+  else throwUnexpected
 
-/-- `matchStr re` accepts and returns substring matches for regex `re` groups, otherwise fails -/
-def matchStr [Parser.Error ε Substring.Raw Char] (re : RegEx Char) :
-  ParserT ε Substring.Raw Char m (Array (Option Substring.Raw)) := do
-  let ⟨str,_,_⟩ ← getStream
+/--
+`matchStr re` accepts and returns the `String.Slice` matches for regex `re` groups, otherwise fails
+-/
+def matchStr [Parser.Error ε String.Slice Char] (re : RegEx Char) :
+  ParserT ε String.Slice Char m (Array (Option String.Slice)) := do
+  let s ← getStream
   let ms ← re.match
   return ms.map fun
-    | some (start, stop) => some ⟨str, start, stop⟩
+    | some (start, stop) =>
+      if h : start.IsValid s.str ∧ stop.IsValid s.str ∧ start ≤ stop then
+        some ⟨s.str, ⟨start, h.1⟩ , ⟨stop, h.2.1⟩, h.2.2⟩
+      else unreachable!
     | none => none
 
 /-- Parse space (U+0020) -/

--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -26,9 +26,9 @@ def chars (tks : String) : ParserT ε σ Char m String :=
     return acc
 
 /-- `string tks` accepts and returns string `tks`, otherwise fails -/
-def string [Parser.Error ε String.Slice Char] (tks : String) :
-    ParserT ε String.Slice Char m String :=
-  withErrorMessage s!"expected {repr tks}" do
+def string [Parser.Error ε String.Slice Char] (tks : String.Slice) :
+    ParserT ε String.Slice Char m String.Slice :=
+  withErrorMessage s!"expected {repr tks.toString}" do
     match (← getStream).dropPrefix? tks with
     | some s =>
       setStream s
@@ -37,14 +37,17 @@ def string [Parser.Error ε String.Slice Char] (tks : String) :
       throwUnexpected
 
 /-- `captureStr p` parses `p` and returns the output of `p` with the corresponding `String.Slice` -/
-def captureStr [Parser.Error ε String.Slice Char] (p : ParserT ε String.Slice Char m α) :
+def captureStr {α} [h : Parser.Error ε String.Slice Char] (p : ParserT ε String.Slice Char m α) :
   ParserT ε String.Slice Char m (α × String.Slice) := do
   let s ← getStream
   let (x, start, stop) ← withCapture p
   -- This should always hold
-  if h : start.IsValid s.str ∧ stop.IsValid s.str ∧ start ≤ stop then
-    return (x, ⟨s.str, ⟨start, h.1⟩ , ⟨stop, h.2.1⟩, String.Pos.le_iff.1 h.2.2⟩)
-  else throwUnexpected
+  if h' : start.IsValid s.str ∧ stop.IsValid s.str ∧ start ≤ stop then
+    return (x, ⟨s.str, ⟨start, h'.1⟩ , ⟨stop, h'.2.1⟩, String.Pos.le_iff.1 h'.2.2⟩)
+  else
+    have : Inhabited (ParserT ε String.Slice Char m (α × String.Slice)) :=
+      ⟨fun s => return .error s (h.unexpected 0 none)⟩
+    unreachable!
 
 /--
 `matchStr re` accepts and returns the `String.Slice` matches for regex `re` groups, otherwise fails

--- a/Parser/RegEx/Compile.lean
+++ b/Parser/RegEx/Compile.lean
@@ -45,7 +45,7 @@ public section
 namespace Parser.RegEx
 open Char
 
-private abbrev REParser := TrivialParser Substring.Raw Char
+private abbrev REParser := TrivialParser String.Slice Char
 
 mutual
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ name = "Parser"
 git = "https://github.com/fgdorais/lean4-parser"
 rev = "main"
 ```
-Then add `import Parser` at the top of any Lean file where you plan to use this library. 
+Then add `import Parser` at the top of any Lean file where you plan to use this library.
 For example:
 ```lean
 import Parser
@@ -24,7 +24,7 @@ open Parser Char
 /--
 Parses a list of sign-separated integers (no spaces) from an input string and returns the sum.
 -/
-def parseSum : SimpleParser Substring Char Int := do
+def parseSum : SimpleParser String.Slice Char Int := do
   let mut sum : Int := 0
   -- parse until all input is consumed
   while ! (← test endOfInput) do

--- a/test/issue-35.lean
+++ b/test/issue-35.lean
@@ -3,7 +3,7 @@ import Parser.Char
 open Parser
 
 def test : Bool :=
-  match Parser.run (Char.string "abc" : SimpleParser Substring Char String) "abc" with
+  match Parser.run (Char.string "abc" : SimpleParser String.Slice Char String) "abc" with
   | .ok s r => s == "" && r == "abc"
   | .error _ _ => false
 

--- a/test/issue-39.lean
+++ b/test/issue-39.lean
@@ -3,7 +3,7 @@ import Parser
 open Parser
 
 def test :=
-  match (endOfInput : TrivialParser Substring Char Unit).run "abcd" with
+  match (endOfInput : TrivialParser String.Slice Char Unit).run "abcd" with
   | .ok _ _ => false
   | .error _ _ => true
 

--- a/test/readme-example.lean
+++ b/test/readme-example.lean
@@ -1,0 +1,18 @@
+import Parser
+
+open Parser Char
+
+/--
+Parses a list of sign-separated integers (no spaces) from an input string and returns the sum.
+-/
+def parseSum : SimpleParser String.Slice Char Int := do
+  let mut sum : Int := 0
+  -- parse until all input is consumed
+  while ! (← test endOfInput) do
+    -- parse an integer (decimal only) and add to sum
+    sum := sum + (← ASCII.parseInt)
+  return sum
+
+#guard 42 == match parseSum.run "11-1+2-3+33" with
+  | .ok _ sum => sum
+  | .error _ e => panic! (toString e)


### PR DESCRIPTION
According to the documentation of `Substring.Raw` it will be deprecated in the future. Therefore it makes sense to use the newer `String.Slice` instead in the examples and in `Parser.Char`. The instance `Parser.Stream.instRawChar` is not removed.

In `Parser.Char.Basic` there are some proofs needed for which I currently found no better solution than testing them at runtime.