### PR TITLE
Add stream to Parser.Error, enabling nicer error messages.

### DIFF
--- a/Parser/Char/Basic.lean
+++ b/Parser/Char/Basic.lean
@@ -46,7 +46,7 @@ def captureStr {α} [h : Parser.Error ε String.Slice Char] (p : ParserT ε Stri
     return (x, ⟨s.str, ⟨start, h'.1⟩ , ⟨stop, h'.2.1⟩, String.Pos.le_iff.1 h'.2.2⟩)
   else
     have : Inhabited (ParserT ε String.Slice Char m (α × String.Slice)) :=
-      ⟨fun s => return .error s (h.unexpected 0 none)⟩
+      ⟨fun s => return .error s (h.unexpected s 0 none)⟩
     unreachable!
 
 /--

--- a/Parser/Error.lean
+++ b/Parser/Error.lean
@@ -31,17 +31,18 @@ This class declares an error type for a given parser stream.
 Given `Parser.Stream σ τ`, `Parser.Error ε σ τ` provides two basic mechanisms for reporting parsing
 errors:
 
-* `unexpected (p : Stream.Position σ) (t : Option τ) : ε`
-  is used to report an unexpected input at a given position, optionally with the offending token.
-* `addMessage (e : ε) (p : Stream.Position σ) (info : String)`
+* `unexpected (s : σ) (p : Stream.Position σ) (t : Option τ) : ε`
+  is used to report an unexpected input in at a given position in the stream `s`,
+  optionally with the offending token.
+* `addMessage (e : ε) (s : σ) (p : Stream.Position σ) (info : String)`
   is used to add additional error information at a given position.
 
 This class can be extended to provide additional error reporting and processing functonality, but
 only these two mechanisms are used within the library.
 -/
 protected class Parser.Error (ε σ : Type _) (τ : outParam (Type _)) [Parser.Stream σ τ] where
-  unexpected : Stream.Position σ → Option τ → ε
-  addMessage : ε → Stream.Position σ → String → ε
+  unexpected : σ → Stream.Position σ → Option τ → ε
+  addMessage : ε → σ → Stream.Position σ → String → ε
 attribute [inherit_doc Parser.Error] Parser.Error.unexpected Parser.Error.addMessage
 
 namespace Parser.Error
@@ -54,8 +55,8 @@ or where parsing errors are intended to be handled by other means.
 abbrev Trivial := Unit
 
 instance (σ τ) [Parser.Stream σ τ] : Parser.Error Trivial σ τ where
-  unexpected _ _ := ()
-  addMessage e _ _ := e
+  unexpected _ _ _ := ()
+  addMessage e _ _ _ := e
 
 /-- *Basic error type*
 
@@ -66,8 +67,8 @@ parsing errors is predictable and only the position of the error is needed for p
 abbrev Basic (σ τ) [Parser.Stream σ τ] := Parser.Stream.Position σ × Option τ
 
 instance (σ τ) [Parser.Stream σ τ] : Parser.Error (Basic σ τ) σ τ where
-  unexpected p t := (p, t)
-  addMessage e _ _ := e
+  unexpected _ p t := (p, t)
+  addMessage e _ _ _ := e
 
 instance (σ τ) [Repr τ] [Parser.Stream σ τ] [Repr (Parser.Stream.Position σ)] :
   ToString (Basic σ τ) where
@@ -126,7 +127,7 @@ instance (σ τ) [Repr τ] [Parser.Stream σ τ] [Repr (Parser.Stream.Position �
   toString := Simple.toString
 
 instance (σ τ) [Parser.Stream σ τ] : Parser.Error (Simple σ τ) σ τ where
-  unexpected := Simple.unexpected
-  addMessage := Simple.addMessage
+  unexpected _ := Simple.unexpected
+  addMessage e _ := Simple.addMessage e
 
 end Parser.Error

--- a/Parser/Parser.lean
+++ b/Parser/Parser.lean
@@ -168,17 +168,17 @@ def withCapture (p : ParserT ε σ τ m α) :
 /-- Throw error on unexpected token. -/
 @[inline]
 def throwUnexpected (input : Option τ := none) : ParserT ε σ τ m α := do
-  throw (Error.unexpected (← getPosition) input)
+  throw (Error.unexpected (← getStream) (← getPosition) input)
 
 /-- Throw error with additional message. -/
 @[inline]
 def throwErrorWithMessage (e : ε) (msg : String) : ParserT ε σ τ m α := do
-  throw (Error.addMessage e (← getPosition) msg)
+  throw (Error.addMessage e (← getStream) (← getPosition) msg)
 
 /-- Throw error on unexpected token with error message. -/
 @[inline]
 def throwUnexpectedWithMessage (input : Option τ := none) (msg : String) : ParserT ε σ τ m α := do
-  throwErrorWithMessage (Error.unexpected (← getPosition) input) msg
+  throwErrorWithMessage (Error.unexpected (← getStream) (← getPosition) input) msg
 
 /-- Add message on parser error. -/
 @[inline]
@@ -216,7 +216,7 @@ def efoldlP (f : β → α → ParserT ε σ τ m β) (init : β) (p : ParserT �
   fun s =>
     have : Inhabited β := ⟨init⟩
     have : Inhabited σ := ⟨s⟩
-    have : Inhabited ε := ⟨Error.unexpected (Stream.getPosition s) none⟩
+    have : Inhabited ε := ⟨Error.unexpected s (Stream.getPosition s) none⟩
     efoldlPAux f p init s
 
 /--
@@ -354,7 +354,7 @@ The default is to only report the error from the last parser.
 -/
 def first (ps : List (ParserT ε σ τ m α)) (combine : ε → ε → ε := fun _ => id) :
   ParserT ε σ τ m α := do
-  go ps (Error.unexpected (← getPosition) none)
+  go ps (Error.unexpected (← getStream) (← getPosition) none)
 where
   go : List (ParserT ε σ τ m α) → ε → ParserT ε σ τ m α
     | [], e, s => return .error s e


### PR DESCRIPTION
Add the stream to `Parser.Error` as follows:
```
protected class Parser.Error (ε σ : Type _) (τ : outParam (Type _)) [Parser.Stream σ τ] where
  unexpected : σ → Stream.Position σ → Option τ → ε
  addMessage : ε → σ → Stream.Position σ → String → ε
```
This makes it possible to use (parts of) the stream when displaying error messages. This is particular useful in string parsers, where it would enable displaying the line where the error occurred. While I have not tested performance yet, I expect that the change should not effect performance to much, assuming that the underlying stream is not modified. 
This is especially the case for #124, but even without this pr I think at most some references to the underlying `String`/`Array`/... and some positions will be duplicated. 

If there is interest, I would be happy to make a pr adding nicer error formatting for string parsers to the library.